### PR TITLE
Add user and garden seeds, expose additional garden attr in api response

### DIFF
--- a/app/serializers/garden_serializer.rb
+++ b/app/serializers/garden_serializer.rb
@@ -3,6 +3,7 @@ class GardenSerializer
   attributes :latitude
   attributes :longitude
   attributes :name
+  attributes :private
 
   has_many :user_gardens
   has_many :users, through: :user_gardens

--- a/app/serializers/garden_serializer.rb
+++ b/app/serializers/garden_serializer.rb
@@ -3,6 +3,7 @@ class GardenSerializer
   attributes :latitude
   attributes :longitude
   attributes :name
+  attributes :description
   attributes :private
 
   has_many :user_gardens

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,13 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+UserGarden.destroy_all
+Garden.destroy_all
+User.destroy_all
+
+user1 = User.create(email: 'user@gmail.com', provider: 'google', token: '1234', refresh_token: '5678', uid: '111')
+user2 = User.create(email: 'communitygarden@gmail.com', provider: 'google', token: '2345', refresh_token: '6789', uid: '222')
+
+user1.gardens << Garden.create(latitude: '39.75', longitude: '-104.996577', name: 'The Grove', description: 'Corner garden', private: true)
+user2.gardens << Garden.create(latitude: '39.45', longitude: '-104.58', name: 'Cole Community Garden', description: 'A diverse, dedicated group of students and neighbors who believe in bettering ourselves, our food supply and our community through urban gardening.', private: false)

--- a/spec/requests/api/v1/garden_request_spec.rb
+++ b/spec/requests/api/v1/garden_request_spec.rb
@@ -38,8 +38,10 @@ describe 'garden API' do
         expect(garden[:attributes]).to have_key(:name)
         expect(garden[:attributes][:name]).to be_an(String)
 
+        expect(garden[:attributes]).to have_key(:description)
+
         expect(garden[:attributes]).to have_key(:private)
-        expect(garden[:attributes][:name]).to be_a(String)
+        expect(garden[:attributes][:private]).to be_in([true, false])
       end
     end
 

--- a/spec/requests/api/v1/garden_request_spec.rb
+++ b/spec/requests/api/v1/garden_request_spec.rb
@@ -37,6 +37,9 @@ describe 'garden API' do
 
         expect(garden[:attributes]).to have_key(:name)
         expect(garden[:attributes][:name]).to be_an(String)
+
+        expect(garden[:attributes]).to have_key(:private)
+        expect(garden[:attributes][:name]).to be_a(String)
       end
     end
 
@@ -68,6 +71,9 @@ describe 'garden API' do
         expect(garden[:attributes][:latitude]).to eq(new_garden.latitude)
         expect(garden[:attributes][:longitude]).to eq(new_garden.longitude)
         expect(garden[:attributes][:name]).to eq(new_garden.name)
+
+        expect(garden[:attributes]).to have_key(:private)
+        expect(garden[:attributes][:name]).to be_a(String)
       end
 
       it 'can create a new garden' do
@@ -81,6 +87,7 @@ describe 'garden API' do
         expect(garden.longitude).to eq(garden_params[:longitude])
         expect(garden.latitude).to eq(garden_params[:latitude])
         expect(garden.name).to eq(garden_params[:name])
+        expect(garden.private).to eq(garden_params[:private])
       end
 
       it 'can update an existing garden' do


### PR DESCRIPTION
closes #57 

**What was changed:**
- Added user and garden (1 public, 1 private) seeds to seed file
- Garden API response:
  - Added garden's private attribute to garden serializer (added test to garden_request_spec, which is passing)
  - Added garden's description to garden serializer (added test to garden_request_spec, which is passing)

