### PR TITLE
Sensor search

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::SearchController < ApplicationController
+  def index
+    return nil if params['start'].nil? || params['stop'].nil? || params['sensor_id'].nil?
+    start = params['start']
+    stop = params['stop']
+    sensor = Sensor.find(params['sensor_id'])
+    render json: GardenHealthSerializer.new(sensor.search_readings_between_dates(start, stop))
+  end
+end

--- a/app/models/sensor.rb
+++ b/app/models/sensor.rb
@@ -6,4 +6,9 @@ class Sensor < ApplicationRecord
   has_many :garden_healths
 
   enum sensor_type: %w(moisture light)
+
+  def search_readings_between_dates(start, stop)
+    garden_healths
+      .where(garden_healths: {created_at: "#{start} 00:00:00".."#{stop} 23:59:59"})
+  end
 end

--- a/app/serializers/garden_health_serializer.rb
+++ b/app/serializers/garden_health_serializer.rb
@@ -1,4 +1,4 @@
 class GardenHealthSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id, :reading_type, :reading, :time_of_reading
+  attributes :id, :reading_type, :reading, :created_at
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
+      get '/garden_healths/search', to: 'search#index'
       resources :plants
       resources :garden_healths
-      get '/garden_healths/search', to: 'search#index'
       resources :users
       resources :gardens
       resources :sensors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
+      get '/garden_healths/search', to: 'search#index'
       resources :plants
       resources :garden_healths
       resources :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      get '/garden_healths/search', to: 'search#index'
       resources :plants
       resources :garden_healths
+      get '/garden_healths/search', to: 'search#index'
       resources :users
       resources :gardens
       resources :sensors

--- a/spec/requests/api/v1/garden_healths_spec.rb
+++ b/spec/requests/api/v1/garden_healths_spec.rb
@@ -43,8 +43,7 @@ RSpec.describe 'GardenHealth API' do
       garden_health_params = {
                               sensor_id: sensor.id,
                               reading_type: 0,
-                              reading: 123.456,
-                              time_of_reading: "2020-10-29 03:05:41.000000000 +0000"
+                              reading: 123.456
                             }
 
       headers = { "CONTENT_TYPE" => "application/json" }
@@ -60,7 +59,6 @@ RSpec.describe 'GardenHealth API' do
       expect(garden_health.sensor_id).to eq(sensor.id)
       expect(garden_health.reading_type).to eq("moisture")
       expect(garden_health.reading).to eq(garden_health_params[:reading])
-      expect(garden_health.time_of_reading).to eq(garden_health_params[:time_of_reading])
     end
 
     it "can update a garden health record" do
@@ -107,8 +105,8 @@ RSpec.describe 'GardenHealth API' do
       expect(garden_health[:attributes][:reading_type]).to be_a(String)
       expect(garden_health[:attributes]).to have_key(:reading)
       expect(garden_health[:attributes][:reading]).to be_a(Float)
-      expect(garden_health[:attributes]).to have_key(:time_of_reading)
-      expect(garden_health[:attributes][:time_of_reading]).to be_a(String)
+      expect(garden_health[:attributes]).to have_key(:created_at)
+      expect(garden_health[:attributes][:created_at]).to be_a(String)
     end
   end
 

--- a/spec/requests/api/v1/search_sepc.rb
+++ b/spec/requests/api/v1/search_sepc.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "search endpoint" do
+  describe 'happy path' do
+    before :each do
+      @user = create :user
+      @garden = create(:garden)
+      @user_garden = create(:user_garden, user_id: @user.id, garden_id: @garden.id)
+      @light_sensor = create(:sensor, :light_sensor, garden_id: @garden.id)
+    end
+    it 'searches a specific sensors readings between two dates' do
+      start_time = DateTime.now.to_s
+      searched_readings = create_list(:garden_health, 5, sensor_id: @light_sensor.id, reading_type: 1)
+      sleep(1)
+      stop_time = DateTime.now.to_s
+
+      irrelevant_readings = create_list(:garden_health, 5, sensor_id: @light_sensor.id, reading_type: 1)
+
+      get "/api/v1/garden_healths/search?start=#{start_time}&stop=#{stop_time}&sensor_id=#{@light_sensor.id}"
+
+      expect(response).to be_successful
+
+      found_readings = JSON.parse(response.body, symbolize_names: true)
+
+      found_readings[:data].each_with_index do |reading, index|
+        expect(reading[:attributes][:id]).to eq(searched_readings[index].id)
+        expect(reading[:attributes][:reading_type]).to eq(searched_readings[index].reading_type)
+        expect(reading[:attributes][:reading]).to eq(searched_readings[index].reading)
+        expect(reading[:attributes][:created_at].to_date).to eq(searched_readings[index].created_at.to_date)
+      end
+    end
+  end
+  describe 'sad path' do
+    it 'cannot search a specific sensors readings if a parameter is not given' do
+      start_time = DateTime.now.to_s
+      stop_time = DateTime.now.to_s
+
+      get "/api/v1/garden_healths/search?start=#{start_time}&stop=#{stop_time}"
+      expect(response.body).to eq("")
+
+      get "/api/v1/garden_healths/search?start=#{start_time}&sensor_id=#{@light_sensor.id}"
+      expect(response.body).to eq("")
+
+      get "/api/v1/garden_healths/search?stop=#{stop_time}&sensor_id=#{@light_sensor.id}"
+      expect(response.body).to eq("")
+    end
+  end
+end

--- a/spec/requests/api/v1/search_spec.rb
+++ b/spec/requests/api/v1/search_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 RSpec.describe "search endpoint" do
+  before :each do
+    @user = create :user
+    @garden = create(:garden)
+    @user_garden = create(:user_garden, user_id: @user.id, garden_id: @garden.id)
+    @light_sensor = create(:sensor, :light_sensor, garden_id: @garden.id)
+  end
   describe 'happy path' do
-    before :each do
-      @user = create :user
-      @garden = create(:garden)
-      @user_garden = create(:user_garden, user_id: @user.id, garden_id: @garden.id)
-      @light_sensor = create(:sensor, :light_sensor, garden_id: @garden.id)
-    end
     it 'searches a specific sensors readings between two dates' do
       start_time = DateTime.now.to_s
       searched_readings = create_list(:garden_health, 5, sensor_id: @light_sensor.id, reading_type: 1)


### PR DESCRIPTION
 - Added a search feature to search a sensor's readings by date.
 - This endpoint takes 3 params (start, stop and sensor_id)
 - I took out the time_of_reading attribute from the serializer and replaced it with created_at. I did this because created_at is a default attribute which requires no extra work to put in the db. Whereas time_of_reading would have to be coded in when a reading is taken from the hardware.

 - Title of this branch may be a bit misleading. This branch is responsible for searching a specific sensor's garden_healths.
closes #44 