### PR TITLE
Edits plant creation so that plants get same id in our database that …

### DIFF
--- a/app/controllers/api/v1/gardens/plants_controller.rb
+++ b/app/controllers/api/v1/gardens/plants_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Gardens::PlantsController < ApplicationController
     if Plant.exists?(params[:plant_id])
       garden.add_plant(Plant.find(params[:plant_id]))
     else
-      x = garden.create_and_add_plant(params[:plant_id], plant_params)
+      garden.create_and_add_plant(params[:plant_id], plant_params)
       require 'pry'; binding.pry
     end
   end

--- a/app/controllers/api/v1/gardens/plants_controller.rb
+++ b/app/controllers/api/v1/gardens/plants_controller.rb
@@ -4,7 +4,8 @@ class Api::V1::Gardens::PlantsController < ApplicationController
     if Plant.exists?(params[:plant_id])
       garden.add_plant(Plant.find(params[:plant_id]))
     else
-      garden.create_and_add_plant(plant_params)
+      x = garden.create_and_add_plant(params[:plant_id], plant_params)
+      require 'pry'; binding.pry
     end
   end
 

--- a/app/controllers/api/v1/gardens/plants_controller.rb
+++ b/app/controllers/api/v1/gardens/plants_controller.rb
@@ -5,7 +5,6 @@ class Api::V1::Gardens::PlantsController < ApplicationController
       garden.add_plant(Plant.find(params[:plant_id]))
     else
       garden.create_and_add_plant(params[:plant_id], plant_params)
-      require 'pry'; binding.pry
     end
   end
 

--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -12,8 +12,10 @@ class Garden < ApplicationRecord
     GardenPlant.create!(garden: self, plant: plant, planted_date: Date.today)
   end
 
-  def create_and_add_plant(plant_params)
-    plant = Plant.new(plant_params)
+  def create_and_add_plant(plant_id, plant_params)
+    plant = Plant.new(plant_params) do |plant|
+      plant.id = plant_id 
+    end
     if plant.save
       GardenPlant.create!(garden: self, plant: plant, planted_date: Date.today)
     end

--- a/spec/models/garden_spec.rb
+++ b/spec/models/garden_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Garden, type: :model do
         harvest_time: 'time to harvest',
         common_pests: 'common pests for plant',
       }
-      garden.create_and_add_plant(plant_params)
+      garden.create_and_add_plant('12', plant_params)
       expect(garden.plants.count).to eq(1)
       expect(garden.plants.first.name).to eq(plant_params[:name])
       expect(garden.plants.first.image).to eq(plant_params[:image])
@@ -56,6 +56,7 @@ RSpec.describe Garden, type: :model do
       expect(garden.plants.first.water_requirements).to eq(plant_params[:water_requirements])
       expect(garden.plants.first.harvest_time).to eq(plant_params[:harvest_time])
       expect(garden.plants.first.common_pests).to eq(plant_params[:common_pests])
+      expect(garden.plants.first.id).to eq(12)
     end
   end
 end

--- a/spec/requests/api/v1/gardens/plant_request_spec.rb
+++ b/spec/requests/api/v1/gardens/plant_request_spec.rb
@@ -13,7 +13,7 @@ describe 'Gardens' do
       when_to_plant: 'when to plant',
       harvest_time: 'time to harvest',
       common_pests: 'common pests for plant',
-      plant_id: '12'
+      plant_id: '14'
     }
     headers = {"CONTENT_TYPE" => "application/json"}
     post "/api/v1/gardens/#{garden.id}/plants", headers: headers, params: JSON.generate(plant_params)
@@ -34,7 +34,7 @@ describe 'Gardens' do
     expect(garden.plants).to eq([plant])
   end
 
-  it "can add a plant if it doesn't exist in the database" do 
+  it "can add a plant if it does exist in the database" do 
     garden = create(:garden)
     db_plant = create(:plant)
     plant_params = { 


### PR DESCRIPTION
…they have in the API

#69 

This way makes sense to me since I believe to stay ReSTful, we need to keep the `:id` param as the gardens id, and therefore can't pass it in with the `plant_params` method. But I could be wrong about that.